### PR TITLE
fix: Adds type annotations for a couple of functions.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'winston';
 
 
-export const withErrorHandling = (logger?: Logger) => (fn: (...args: any[]) => any) => async (...args: any[]) => {
+export const withErrorHandling = <Args extends Array<T>, Res, T>(logger: Logger, fn: (...args: Args) => Res) => async (...args: Args) => {
   let result;
   try {
     result = await fn(...args);


### PR DESCRIPTION
Also modifies `withErrorHandling` so that it has two parameters instead of currying them into single parameter functions.

I'm not sure why, but it looks like the typescript compiler is not able to infer the type of a generic type variable through a function call (or perhaps something else?). This is why I had `withErrorHandling` take both the logger and the function it wraps instead of currying them.